### PR TITLE
Add portfolio history charts and track totals

### DIFF
--- a/src/web/static/style.css
+++ b/src/web/static/style.css
@@ -121,6 +121,49 @@ h1, h2, h3 {
     margin-top: 0;
 }
 
+.chart-placeholder {
+    color: var(--secondary-color);
+    font-style: italic;
+    margin-top: 0.5rem;
+}
+
+.asset-charts-grid {
+    display: grid;
+    gap: 1.5rem;
+    margin-top: 1rem;
+}
+
+.asset-chart {
+    border: 1px solid var(--border-color);
+    border-radius: var(--border-radius);
+    padding: 1rem;
+    background-color: var(--surface-color);
+    box-shadow: var(--box-shadow);
+    position: relative;
+}
+
+.asset-chart h4 {
+    margin-top: 0;
+}
+
+.asset-chart canvas {
+    width: 100%;
+    height: 220px;
+    display: block;
+}
+
+#portfolio-history-chart {
+    width: 100%;
+    height: 220px;
+    display: block;
+}
+
+@media (min-width: 768px) {
+    .asset-charts-grid {
+        grid-template-columns: repeat(2, 1fr);
+    }
+}
+
 /* Tables */
 table {
     width: 100%;

--- a/src/web/templates/dashboard.html
+++ b/src/web/templates/dashboard.html
@@ -83,9 +83,22 @@
     <div id="balances-error" style="display:none; color: var(--danger-color);"></div>
 </div>
 
+<div class="card">
+    <h2>Histórico de Valor da Carteira</h2>
+    <p id="portfolio-history-empty" class="chart-placeholder" style="display:none;">Nenhum histórico disponível ainda.</p>
+    <canvas id="portfolio-history-chart" height="220" style="display:none;"></canvas>
+</div>
+
+<div class="card">
+    <h2>Desempenho por Ativo</h2>
+    <p id="asset-charts-empty" class="chart-placeholder" style="display:none;">Nenhum histórico disponível para os ativos.</p>
+    <div id="asset-charts-container" class="asset-charts-grid"></div>
+</div>
+
 {% endblock %}
 
 {% block scripts %}
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.4/dist/chart.umd.min.js"></script>
 <script>
 document.addEventListener('DOMContentLoaded', function () {
     const runBtn = document.getElementById('run-rebalance-btn');
@@ -173,7 +186,182 @@ document.addEventListener('DOMContentLoaded', function () {
         }
     }
 
+    const currencyFormatter = new Intl.NumberFormat('pt-BR', { style: 'currency', currency: 'USD', maximumFractionDigits: 2 });
+    const quantityFormatter = new Intl.NumberFormat('pt-BR', { maximumFractionDigits: 8 });
+    const chartPalette = [
+        { border: '#0d6efd', background: 'rgba(13, 110, 253, 0.12)' },
+        { border: '#20c997', background: 'rgba(32, 201, 151, 0.12)' },
+        { border: '#d63384', background: 'rgba(214, 51, 132, 0.12)' },
+        { border: '#fd7e14', background: 'rgba(253, 126, 20, 0.12)' },
+        { border: '#6610f2', background: 'rgba(102, 16, 242, 0.12)' },
+        { border: '#198754', background: 'rgba(25, 135, 84, 0.12)' },
+        { border: '#6c757d', background: 'rgba(108, 117, 125, 0.12)' },
+        { border: '#0dcaf0', background: 'rgba(13, 202, 240, 0.12)' },
+    ];
+
+    async function fetchPortfolioHistory() {
+        const portfolioCanvas = document.getElementById('portfolio-history-chart');
+        const portfolioEmpty = document.getElementById('portfolio-history-empty');
+        const assetContainer = document.getElementById('asset-charts-container');
+        const assetEmpty = document.getElementById('asset-charts-empty');
+
+        if (!portfolioCanvas || !assetContainer || typeof Chart === 'undefined') {
+            return;
+        }
+
+        try {
+            const response = await fetch('/api/v1/history/portfolio-stats');
+            if (!response.ok) {
+                throw new Error('Resposta inválida do servidor');
+            }
+            const data = await response.json();
+
+            const portfolioData = Array.isArray(data.portfolio) ? data.portfolio : [];
+            if (portfolioData.length === 0) {
+                portfolioCanvas.style.display = 'none';
+                portfolioEmpty.style.display = 'block';
+            } else {
+                portfolioEmpty.style.display = 'none';
+                portfolioCanvas.style.display = 'block';
+                const labels = portfolioData.map(point => new Date(point.timestamp).toLocaleString('pt-BR'));
+                const values = portfolioData.map(point => Number(point.total_value_usd ?? 0));
+
+                const existingPortfolioChart = Chart.getChart(portfolioCanvas);
+                if (existingPortfolioChart) {
+                    existingPortfolioChart.destroy();
+                }
+
+                new Chart(portfolioCanvas.getContext('2d'), {
+                    type: 'line',
+                    data: {
+                        labels,
+                        datasets: [{
+                            label: 'Valor da carteira (USD)',
+                            data: values,
+                            borderColor: '#0d6efd',
+                            backgroundColor: 'rgba(13, 110, 253, 0.12)',
+                            tension: 0.25,
+                            fill: true,
+                            pointRadius: 3,
+                        }]
+                    },
+                    options: {
+                        responsive: true,
+                        maintainAspectRatio: false,
+                        scales: {
+                            y: {
+                                ticks: {
+                                    callback: (value) => currencyFormatter.format(value ?? 0),
+                                }
+                            }
+                        },
+                        plugins: {
+                            legend: { display: false },
+                            tooltip: {
+                                callbacks: {
+                                    label: (context) => `Valor: ${currencyFormatter.format(context.parsed.y ?? 0)}`,
+                                }
+                            }
+                        }
+                    }
+                });
+            }
+
+            const assetEntries = Object.entries(data.assets || {}).filter(([, points]) => Array.isArray(points) && points.length > 0);
+            assetContainer.innerHTML = '';
+
+            if (assetEntries.length === 0) {
+                assetEmpty.style.display = 'block';
+            } else {
+                assetEmpty.style.display = 'none';
+                let colorIndex = 0;
+
+                for (const [asset, points] of assetEntries) {
+                    const wrapper = document.createElement('div');
+                    wrapper.className = 'asset-chart';
+
+                    const title = document.createElement('h4');
+                    title.textContent = asset;
+                    wrapper.appendChild(title);
+
+                    const canvas = document.createElement('canvas');
+                    canvas.height = 220;
+                    wrapper.appendChild(canvas);
+
+                    assetContainer.appendChild(wrapper);
+
+                    const labels = points.map(point => new Date(point.timestamp).toLocaleString('pt-BR'));
+                    const values = points.map(point => Number(point.value_usd ?? 0));
+                    const quantities = points.map(point => point.quantity !== undefined && point.quantity !== null ? Number(point.quantity) : null);
+
+                    const paletteEntry = chartPalette[colorIndex % chartPalette.length];
+                    colorIndex += 1;
+
+                    new Chart(canvas.getContext('2d'), {
+                        type: 'line',
+                        data: {
+                            labels,
+                            datasets: [{
+                                label: `Valor de ${asset} (USD)`,
+                                data: values,
+                                borderColor: paletteEntry.border,
+                                backgroundColor: paletteEntry.background,
+                                tension: 0.25,
+                                fill: true,
+                                pointRadius: 2.5,
+                            }]
+                        },
+                        options: {
+                            responsive: true,
+                            maintainAspectRatio: false,
+                            scales: {
+                                y: {
+                                    ticks: {
+                                        callback: (value) => currencyFormatter.format(value ?? 0),
+                                    }
+                                }
+                            },
+                            plugins: {
+                                legend: { display: false },
+                                tooltip: {
+                                    callbacks: {
+                                        label: (context) => {
+                                            const idx = context.dataIndex;
+                                            const parts = [`Valor: ${currencyFormatter.format(context.parsed.y ?? 0)}`];
+                                            const quantity = quantities[idx];
+                                            if (quantity !== null) {
+                                                parts.push(`Quantidade: ${quantityFormatter.format(quantity)}`);
+                                            }
+                                            return parts;
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    });
+                }
+            }
+        } catch (error) {
+            console.error('Erro ao carregar histórico da carteira', error);
+            if (portfolioCanvas) {
+                portfolioCanvas.style.display = 'none';
+            }
+            if (portfolioEmpty) {
+                portfolioEmpty.textContent = `Não foi possível carregar o histórico da carteira: ${error.message}`;
+                portfolioEmpty.style.display = 'block';
+            }
+            if (assetContainer) {
+                assetContainer.innerHTML = '';
+            }
+            if (assetEmpty) {
+                assetEmpty.textContent = `Não foi possível carregar os gráficos dos ativos: ${error.message}`;
+                assetEmpty.style.display = 'block';
+            }
+        }
+    }
+
     fetchBalances();
+    fetchPortfolioHistory();
 });
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- record portfolio valuation totals for each rebalance run
- expose a new portfolio statistics endpoint and display interactive charts on the dashboard
- style the new charts and expand tests to cover the aggregated data

## Testing
- PYTHONPATH=src pytest

------
https://chatgpt.com/codex/tasks/task_e_68ce1b4748648324a0e5b6f56d0f84d2