### PR TITLE
fix(history): sort balances safely for template

### DIFF
--- a/src/web/templates/history.html
+++ b/src/web/templates/history.html
@@ -74,15 +74,15 @@
                         </tr>
                     </thead>
                     <tbody>
-                        {% for asset, details in run.projected_balances.items()|sort(attribute='1.value_usd', reverse=true) %}
+                        {% for asset, details in run.sorted_balances or [] %}
                         <tr>
                             <td>{{ asset }}</td>
-                            <td>{{ "%.8f"|format(details.quantity|float) }}</td>
+                            <td>{{ "%.8f"|format(details.get('quantity', 0)|float) }}</td>
                             {% set value_base = details.get('value_in_base', details.get('value_usd', 0)) %}
                             <td>{{ "%.2f"|format(value_base|float) }} {{ run.base_pair }}</td>
                             <td>
-                                {% if details.value_usd is not none %}
-                                ${{ "%.2f"|format(details.value_usd|float) }}
+                                {% if details.get('value_usd') is not none %}
+                                ${{ "%.2f"|format(details.get('value_usd', 0)|float) }}
                                 {% else %}
                                 —
                                 {% endif %}


### PR DESCRIPTION
## Summary
- add a helper to sort projected balances by USD value with defensive defaults
- pre-compute sorted balances for history runs and expose them to the template
- update the history template to iterate over the safe list and guard missing keys

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cf391616108324ba06b284254958bc