### PR TITLE
fix(rebalance): Correct portfolio value and fee calculation

### DIFF
--- a/src/app/services/rebalance_engine.py
+++ b/src/app/services/rebalance_engine.py
@@ -115,7 +115,7 @@ class RebalanceEngine:
             f"Total portfolio value (including base pair): ${total_portfolio_value:,.2f}"
         )
 
-        if total_eligible_value == 0:
+        if total_portfolio_value == 0:
             logger.warning("Total portfolio value is zero. Nothing to rebalance.")
             return {
                 "proposed_trades": [],
@@ -131,14 +131,14 @@ class RebalanceEngine:
 
             current_value = current_portfolio_values.get(asset, 0.0)
             current_alloc_pct = (
-                (current_value / total_eligible_value) * 100
-                if total_eligible_value
+                (current_value / total_portfolio_value) * 100
+                if total_portfolio_value
                 else 0
             )
             target_alloc_pct = target_allocations.get(asset, 0.0)
 
             delta_pct = target_alloc_pct - current_alloc_pct
-            delta_value_base = (delta_pct / 100) * total_eligible_value
+            delta_value_base = (delta_pct / 100) * total_portfolio_value
 
             if base_to_usd is not None:
                 delta_value_threshold = abs(delta_value_base) * base_to_usd
@@ -203,6 +203,20 @@ class RebalanceEngine:
             side = "BUY" if delta_value_base > 0 else "SELL"
             reason = f"Target: {target_alloc_pct:.2f}%, Current: {current_alloc_pct:.2f}%, Delta: {delta_pct:.2f}%"
 
+            # Check if there are enough funds for a BUY
+            if side == "BUY":
+                cost = final_trade_value * (1 + trade_fee_pct / 100)
+                if cost > balances.get(base_pair, 0.0):
+                    logger.warning(
+                        "Insufficient funds to place BUY order for %s. Need %s %s, have %s %s",
+                        asset,
+                        cost,
+                        base_pair,
+                        balances.get(base_pair, 0.0),
+                        base_pair,
+                    )
+                    continue
+
             proposed_trades.append(
                 ProposedTrade(
                     symbol=symbol,
@@ -233,14 +247,17 @@ class RebalanceEngine:
             base_qty_change = trade.estimated_value_base
 
             if trade.side == "BUY":
-                # Assume fee is paid from the received asset (Binance standard)
+                # Fee is paid from the base pair (e.g., USDT)
                 projected_balances[trade.asset] = projected_balances.get(
                     trade.asset, 0
-                ) + (asset_qty_change * (1 - trade_fee_pct / 100))
-                projected_balances[base_pair] -= base_qty_change
+                ) + asset_qty_change
+                # Cost includes value of asset plus the fee
+                projected_balances[base_pair] -= base_qty_change * (
+                    1 + trade_fee_pct / 100
+                )
             else:  # SELL
                 projected_balances[trade.asset] -= asset_qty_change
-                # Fee is deducted from the quote asset received
+                # Revenue is value of asset minus the fee
                 projected_balances[base_pair] += base_qty_change * (
                     1 - trade_fee_pct / 100
                 )

--- a/tests/integration/test_rebalance_flow.py
+++ b/tests/integration/test_rebalance_flow.py
@@ -114,37 +114,30 @@ async def test_rebalance_flow_direct_call(db_session, monkeypatch, mock_config_m
     # --- Assertions ---
     # Target: BTC 60%, ETH 40%.
     # Sell BTC: 12% of 100k = 12k. Buy ETH: 22% of 100k = 22k.
+    # The BUY trade will be skipped due to insufficient funds.
     assert result.status == "DRY_RUN"
     assert "Simulação concluída" in result.message
-    assert len(result.trades) == 2
+    assert len(result.trades) == 1
 
     sell_trade = next((t for t in result.trades if t.side == "SELL"), None)
     buy_trade = next((t for t in result.trades if t.side == "BUY"), None)
 
     assert sell_trade is not None
+    assert buy_trade is None
     assert sell_trade.asset == "BTC"
-    # With the new logic, rebalancing is based on the eligible asset value ($90k), not total portfolio value ($100k)
-    # Target values: BTC=54k, ETH=36k. Current: BTC=72k, ETH=18k.
-    # Deltas: Sell 18k BTC, Buy 18k ETH.
-    assert sell_trade.estimated_value_base == pytest.approx(18000)
-    assert sell_trade.estimated_value_usd == pytest.approx(18000)
-    assert sell_trade.fee_cost_usd == pytest.approx(18.0)
-
-    assert buy_trade is not None
-    assert buy_trade.asset == "ETH"
-    assert buy_trade.estimated_value_base == pytest.approx(18000)
-    assert buy_trade.estimated_value_usd == pytest.approx(18000)
-    assert buy_trade.fee_cost_usd == pytest.approx(18.0)
+    assert sell_trade.estimated_value_base == pytest.approx(12000)
+    assert sell_trade.estimated_value_usd == pytest.approx(12000)
+    assert sell_trade.fee_cost_usd == pytest.approx(12.0)
 
     # Assert totals and projected balances
-    assert result.total_fees_usd == pytest.approx(36.0)
+    assert result.total_fees_usd == pytest.approx(12.0, rel=1e-3)
     assert result.projected_balances is not None
-    # Initial: 1.2 BTC. Sell 18k/60k = 0.3 BTC. Final: 0.9 BTC
-    assert result.projected_balances["BTC"]["quantity"] == pytest.approx(0.9)
-    # Initial: 6 ETH. Buy 18k/3k = 6 ETH. After fee: 6 * (1-0.001) = 5.994. Final: 11.994 ETH
-    assert result.projected_balances["ETH"]["quantity"] == pytest.approx(11.994)
-    # Initial: 10k USDT. Buy 18k ETH -> -18k. Sell 18k BTC -> +18k*(1-0.001)=17982. Final: 9982
-    assert result.projected_balances["USDT"]["quantity"] == pytest.approx(9982)
+    # Initial: 1.2 BTC. Sell 12k/60k = 0.2 BTC. Final: 1.0 BTC
+    assert result.projected_balances["BTC"]["quantity"] == pytest.approx(1.0)
+    # Initial: 6 ETH. No trade, so it remains 6.
+    assert result.projected_balances["ETH"]["quantity"] == pytest.approx(6.0)
+    # Initial: 10k USDT. Sell 12k BTC -> +11988. Final: 21988
+    assert result.projected_balances["USDT"]["quantity"] == pytest.approx(21988)
 
 
     # Assert database write
@@ -152,12 +145,12 @@ async def test_rebalance_flow_direct_call(db_session, monkeypatch, mock_config_m
     assert db_run is not None
     assert db_run.status == "DRY_RUN"
     assert db_run.is_dry_run is True
-    assert len(db_run.trades_executed) == 2
+    assert len(db_run.trades_executed) == 1
     assert db_run.trades_executed[0]["asset"] == "BTC"
-    assert db_run.total_fees_usd == pytest.approx(36.0)
+    assert db_run.total_fees_usd == pytest.approx(12.0, rel=1e-3)
     assert db_run.total_value_usd_before == pytest.approx(100000.0)
-    assert db_run.total_value_usd_after == pytest.approx(99964.0)
-    assert db_run.projected_balances["BTC"]["quantity"] == pytest.approx(0.9)
+    assert db_run.total_value_usd_after == pytest.approx(99988.0, rel=1e-3)
+    assert db_run.projected_balances["BTC"]["quantity"] == pytest.approx(1.0)
     assert db_run.trigger == "manual"
     assert db_run.base_pair == "USDT"
 

--- a/tests/unit/test_rebalance_engine.py
+++ b/tests/unit/test_rebalance_engine.py
@@ -74,30 +74,30 @@ def test_simple_rebalance(rebalance_engine, mock_data):
     )
     trades = result["proposed_trades"]
 
-    assert len(trades) == 2  # Sell BTC, Buy ETH. USDT change handled by others.
+    assert len(trades) == 1  # Sell BTC. Buy ETH skipped due to insufficient funds.
 
     sell_trade = next(t for t in trades if t.side == "SELL")
-    buy_trade = next(t for t in trades if t.side == "BUY")
+    buy_trade = next((t for t in trades if t.side == "BUY"), None)
 
-    # Based on eligible value of 95k: Sell 18k BTC, Buy 8.5k ETH
+    # Based on TOTAL value of 100k:
+    # Sell BTC: current 75k, target 60k -> Sell 15k
+    # Buy ETH: current 20k, target 30k -> Buy 10k
     assert sell_trade.asset == "BTC"
-    assert sell_trade.estimated_value_base == pytest.approx(18000, rel=1e-3)
-    assert sell_trade.estimated_value_usd == pytest.approx(18000, rel=1e-3)
-    assert sell_trade.quantity == pytest.approx(18000 / 50000, rel=1e-3)
+    assert sell_trade.estimated_value_base == pytest.approx(15000, rel=1e-3)
+    assert sell_trade.estimated_value_usd == pytest.approx(15000, rel=1e-3)
+    assert sell_trade.quantity == pytest.approx(15000 / 50000, rel=1e-3)
 
-    assert buy_trade.asset == "ETH"
-    assert buy_trade.estimated_value_base == pytest.approx(8500, rel=1e-3)
-    assert buy_trade.estimated_value_usd == pytest.approx(8500, rel=1e-3)
-    assert buy_trade.quantity == pytest.approx(8500 / 2000, rel=1e-3)
+    assert buy_trade is None
 
 
 def test_trade_below_min_value_is_ignored(rebalance_engine, mock_data):
     """Test that a trade with a value below min_trade_value_usd is ignored."""
-    # Current allocs: BTC=78.95%, ETH=21.05%. Set targets very close to this.
-    target_allocations = {"BTC": 78.9, "ETH": 21.1, "USDT": 0.0}
+    # Based on total value: Current allocs: BTC=75%, ETH=20%. Set targets very close.
+    target_allocations = {"BTC": 75.05, "ETH": 20.0, "USDT": 4.95}
     mock_data["min_trade_value_usd"] = 100.0  # Set a high min trade value
 
-    # With new logic, delta for BTC is now ~$45, still below the $100 min trade value.
+    # Delta for BTC is 0.05% of 100k = $50, which is below the $100 min trade value.
+    # All other deltas are smaller. No trades should be proposed.
 
     result = rebalance_engine.run(
         balances=mock_data["balances"],
@@ -132,9 +132,9 @@ def test_trade_below_min_notional_is_ignored(rebalance_engine, mock_data):
     )
     trades = result["proposed_trades"]
 
-    # Only the ETH trade should remain
-    assert len(trades) == 1
-    assert trades[0].asset == "ETH"
+    # No trades should be proposed. The BTC trade is below min notional,
+    # and the ETH trade is skipped due to insufficient funds.
+    assert len(trades) == 0
 
 
 def test_asset_not_in_cmc_list_is_ignored(rebalance_engine, mock_data):
@@ -182,7 +182,46 @@ def test_new_asset_to_buy(rebalance_engine, mock_data):
     buy_bnb_trade = next((t for t in trades if t.asset == "BNB"), None)
     assert buy_bnb_trade is not None
     assert buy_bnb_trade.side == "BUY"
-    # Target value is 10% of eligible value (95k) = 9.5k
-    assert buy_bnb_trade.estimated_value_base == pytest.approx(9500, rel=1e-3)
-    assert buy_bnb_trade.estimated_value_usd == pytest.approx(9500, rel=1e-3)
-    assert buy_bnb_trade.quantity == pytest.approx(9500 / 300.0, rel=1e-3)
+    # Target value is 10% of total value (110k) = 11k
+    assert buy_bnb_trade.estimated_value_base == pytest.approx(11000, rel=1e-3)
+    assert buy_bnb_trade.estimated_value_usd == pytest.approx(11000, rel=1e-3)
+    assert buy_bnb_trade.quantity == pytest.approx(11000 / 300.0, rel=1e-3)
+
+
+def test_projected_balances_with_buy_fee(rebalance_engine, mock_data):
+    """
+    Test that projected balances are calculated correctly for a BUY trade,
+    ensuring the fee is paid from the base currency.
+    """
+    balances = {"BTC": 1.0, "USDT": 50000}  # BTC=50k, USDT=50k, Total=100k
+    target_allocations = {"BTC": 80.0, "USDT": 20.0}  # Target: BTC=80k, USDT=20k
+    trade_fee_pct = 0.1  # Buy $30k worth of BTC
+
+    result = rebalance_engine.run(
+        balances=balances,
+        prices=mock_data["prices"],
+        exchange_info=mock_data["exchange_info"],
+        target_allocations=target_allocations,
+        eligible_cmc_symbols=mock_data["eligible_cmc_symbols"],
+        base_pair=mock_data["base_pair"],
+        min_trade_value_usd=mock_data["min_trade_value_usd"],
+        trade_fee_pct=trade_fee_pct,
+    )
+
+    projected = result["projected_balances"]
+    buy_trade = result["proposed_trades"][0]
+
+    # Sanity check the trade proposal
+    assert buy_trade.asset == "BTC"
+    assert buy_trade.side == "BUY"
+    assert buy_trade.estimated_value_base == pytest.approx(30000, rel=1e-3)
+    assert buy_trade.quantity == pytest.approx(0.6, rel=1e-3)
+
+    # Verify projected balances (the CORRECT calculation)
+    # Initial BTC was 1.0, we bought 0.6. Should be 1.6.
+    assert projected["BTC"]["quantity"] == pytest.approx(1.0 + 0.6)
+
+    # Initial USDT was 50000. We spent 30000 on BTC and 0.1% fee on that.
+    # Fee = 30000 * 0.001 = 30 USDT. Total cost = 30030 USDT.
+    # Remaining USDT = 50000 - 30030 = 19970 USDT.
+    assert projected["USDT"]["quantity"] == pytest.approx(19970)


### PR DESCRIPTION
This commit fixes two critical bugs in the rebalancing engine:

1.  The engine now calculates asset allocation percentages based on the total portfolio value, including the base pair. This ensures that the rebalancing logic is applied to the entire portfolio, not just a subset of it.

2.  The engine now correctly deducts fees from the base pair for BUY trades and checks for sufficient funds before proposing a trade. This prevents the engine from proposing impossible trades that would result in a negative balance.

A new unit test has been added to verify the fee calculation, and existing unit and integration tests have been updated to reflect the corrected logic.