### PR TITLE
Fix: Prevent double-spending in rebalance engine

### DIFF
--- a/src/app/services/rebalance_engine.py
+++ b/src/app/services/rebalance_engine.py
@@ -123,8 +123,9 @@ class RebalanceEngine:
                 "projected_balances": {},
             }
 
-        # 3. Calculate deltas and generate proposed trades
-        proposed_trades: List[ProposedTrade] = []
+        # 3. Calculate deltas and identify potential trades
+        potential_trades: List[ProposedTrade] = []
+
         for asset in preliminary_assets:
             if asset == base_pair:
                 continue
@@ -203,22 +204,8 @@ class RebalanceEngine:
             side = "BUY" if delta_value_base > 0 else "SELL"
             reason = f"Target: {target_alloc_pct:.2f}%, Current: {current_alloc_pct:.2f}%, Delta: {delta_pct:.2f}%"
 
-            # Check if there are enough funds for a BUY
-            if side == "BUY":
-                cost = final_trade_value * (1 + trade_fee_pct / 100)
-                if cost > balances.get(base_pair, 0.0):
-                    logger.warning(
-                        "Insufficient funds to place BUY order for %s. Need %s %s, have %s %s",
-                        asset,
-                        cost,
-                        base_pair,
-                        balances.get(base_pair, 0.0),
-                        base_pair,
-                    )
-                    continue
-
-            proposed_trades.append(
-                ProposedTrade(
+            potential_trades.append(
+                 ProposedTrade(
                     symbol=symbol,
                     asset=asset,
                     side=side,
@@ -229,20 +216,110 @@ class RebalanceEngine:
                     fee_cost_usd=fee_cost,
                 )
             )
+
+        # 4. Process trades to ensure fund availability (Double-spend fix)
+        # Segregate BUYs and SELLs
+        sell_trades = [t for t in potential_trades if t.side == "SELL"]
+        buy_trades = [t for t in potential_trades if t.side == "BUY"]
+
+        final_proposed_trades: List[ProposedTrade] = []
+        current_base_balance = balances.get(base_pair, 0.0)
+
+        # Process SELLs first to accumulate funds
+        for trade in sell_trades:
+            final_proposed_trades.append(trade)
+            # Revenue is value of asset minus the fee
+            revenue = trade.estimated_value_base * (1 - trade_fee_pct / 100)
+            current_base_balance += revenue
             logger.info(
-                f"Proposing trade: {side} {adjusted_quantity} {asset} for ~${value_usd:,.2f} (Fee: ~${fee_cost:,.2f})"
+                f"Proposing trade: {trade.side} {trade.quantity} {trade.asset} "
+                f"for ~${trade.estimated_value_usd:,.2f} (Fee: ~${trade.fee_cost_usd:,.2f}). "
+                f"Projected Base Balance: {current_base_balance:.4f}"
             )
 
-        # 4. Calculate projected balances
+        # Process BUYs and check against running balance
+        for trade in buy_trades:
+            cost = trade.estimated_value_base * (1 + trade_fee_pct / 100)
+
+            # If insufficient funds, try to reduce the trade size to fit remaining balance
+            if cost > current_base_balance:
+                logger.warning(
+                    "Insufficient funds to place full BUY order for %s. Need %s %s, have %s %s. "
+                    "Attempting to adjust trade size.",
+                    trade.asset,
+                    cost,
+                    base_pair,
+                    current_base_balance,
+                    base_pair,
+                )
+
+                # Calculate max affordable value in base currency
+                max_affordable_base_value = current_base_balance / (1 + trade_fee_pct / 100)
+
+                # Retrieve symbol info to check filters again
+                symbol_info = exchange_info.get(trade.symbol)
+                if symbol_info:
+                    lot_size_filter = next((f for f in symbol_info.get("filters", []) if f["filterType"] == "LOT_SIZE"), None)
+                    min_notional_filter = next((f for f in symbol_info.get("filters", []) if f["filterType"] in ("MIN_NOTIONAL", "NOTIONAL")), None)
+
+                    if lot_size_filter and min_notional_filter:
+                        step_size = lot_size_filter["stepSize"]
+                        min_notional = float(min_notional_filter["minNotional"])
+
+                        # Price is implicit in trade.estimated_value_base / trade.quantity
+                        # but simpler to just use max_affordable_base_value / price
+                        price = trade.estimated_value_base / trade.quantity if trade.quantity > 0 else 0
+                        if price > 0:
+                            new_quantity = max_affordable_base_value / price
+                            adjusted_quantity = adjust_to_step_size(new_quantity, step_size)
+                            new_trade_value = adjusted_quantity * price
+
+                            if adjusted_quantity > 0 and new_trade_value >= min_notional:
+                                logger.info(f"Adjusting trade for {trade.asset}: Quantity {trade.quantity} -> {adjusted_quantity}")
+                                # Update trade object
+                                trade.quantity = adjusted_quantity
+                                trade.estimated_value_base = new_trade_value
+                                trade.estimated_value_usd = (
+                                    new_trade_value * base_to_usd if base_to_usd is not None else new_trade_value
+                                )
+                                trade.fee_cost_usd = trade.estimated_value_usd * (trade_fee_pct / 100)
+                                trade.reason += " (Adjusted for remaining funds)"
+
+                                # Update cost
+                                cost = new_trade_value * (1 + trade_fee_pct / 100)
+                            else:
+                                logger.warning(f"Remaining funds insufficient for minimum trade size of {trade.asset}. Skipping.")
+                                continue
+                        else:
+                            continue
+                    else:
+                        continue
+                else:
+                    continue
+
+            # Final check in case adjustment failed or wasn't enough (floating point issues)
+            if cost > current_base_balance + 1e-9:
+                 logger.warning(f"Skipping trade for {trade.asset} due to insufficient funds after adjustment.")
+                 continue
+
+            final_proposed_trades.append(trade)
+            current_base_balance -= cost
+            logger.info(
+                f"Proposing trade: {trade.side} {trade.quantity} {trade.asset} "
+                f"for ~${trade.estimated_value_usd:,.2f} (Fee: ~${trade.fee_cost_usd:,.2f}). "
+                f"Projected Base Balance: {current_base_balance:.4f}"
+            )
+
+        # 5. Calculate projected balances
         projected_balances = balances.copy()
-        total_fees_usd = sum(trade.fee_cost_usd for trade in proposed_trades)
+        total_fees_usd = sum(trade.fee_cost_usd for trade in final_proposed_trades)
 
         # Ensure the base_pair key exists before we start modifying it,
         # in case the initial balance for it was zero.
         if base_pair not in projected_balances:
             projected_balances[base_pair] = 0.0
 
-        for trade in proposed_trades:
+        for trade in final_proposed_trades:
             asset_qty_change = trade.quantity
             base_qty_change = trade.estimated_value_base
 
@@ -262,7 +339,7 @@ class RebalanceEngine:
                     1 - trade_fee_pct / 100
                 )
 
-        # 5. Format projected balances with USD values
+        # 6. Format projected balances with USD values
         final_projected_balances = {}
         for asset, qty in projected_balances.items():
             price_in_base = get_asset_base_value(prices, asset, base_pair) or 1.0
@@ -277,7 +354,7 @@ class RebalanceEngine:
             final_projected_balances[asset] = entry
 
         return {
-            "proposed_trades": proposed_trades,
+            "proposed_trades": final_proposed_trades,
             "total_fees_usd": total_fees_usd,
             "projected_balances": final_projected_balances,
         }

--- a/tests/integration/test_rebalance_flow.py
+++ b/tests/integration/test_rebalance_flow.py
@@ -114,42 +114,64 @@ async def test_rebalance_flow_direct_call(db_session, monkeypatch, mock_config_m
     # --- Assertions ---
     # Target: BTC 60%, ETH 40%.
     # Sell BTC: 12% of 100k = 12k. Buy ETH: 22% of 100k = 22k.
-    # The BUY trade will be skipped due to insufficient funds.
+    # Improved Behavior: The BUY trade is now possible using SELL proceeds.
+    # However, total funds (10k + 12k - fees) = ~21988.
+    # Target Buy ETH = 22k. Shortfall ~12.
+    # Logic should reduce Buy size to fit funds.
     assert result.status == "DRY_RUN"
     assert "Simulação concluída" in result.message
-    assert len(result.trades) == 1
+    assert len(result.trades) == 2
 
     sell_trade = next((t for t in result.trades if t.side == "SELL"), None)
     buy_trade = next((t for t in result.trades if t.side == "BUY"), None)
 
     assert sell_trade is not None
-    assert buy_trade is None
+    assert buy_trade is not None
+
+    # Verify SELL BTC
     assert sell_trade.asset == "BTC"
     assert sell_trade.estimated_value_base == pytest.approx(12000)
     assert sell_trade.estimated_value_usd == pytest.approx(12000)
     assert sell_trade.fee_cost_usd == pytest.approx(12.0)
 
+    # Verify BUY ETH (Partial Fill)
+    # Available for Buy: Initial 10000 + Sell Proceeds (12000 * 0.999) = 10000 + 11988 = 21988.
+    # Cost = Value * 1.001.
+    # Max Value = 21988 / 1.001 ~= 21966.03
+    assert buy_trade.asset == "ETH"
+    assert buy_trade.estimated_value_base == pytest.approx(21966, rel=1e-3)
+    assert buy_trade.fee_cost_usd == pytest.approx(21.966, rel=1e-3)
+
     # Assert totals and projected balances
-    assert result.total_fees_usd == pytest.approx(12.0, rel=1e-3)
+    total_fees = 12.0 + buy_trade.fee_cost_usd
+    assert result.total_fees_usd == pytest.approx(total_fees, rel=1e-3)
+
     assert result.projected_balances is not None
     # Initial: 1.2 BTC. Sell 12k/60k = 0.2 BTC. Final: 1.0 BTC
     assert result.projected_balances["BTC"]["quantity"] == pytest.approx(1.0)
-    # Initial: 6 ETH. No trade, so it remains 6.
-    assert result.projected_balances["ETH"]["quantity"] == pytest.approx(6.0)
-    # Initial: 10k USDT. Sell 12k BTC -> +11988. Final: 21988
-    assert result.projected_balances["USDT"]["quantity"] == pytest.approx(21988)
 
+    # Initial: 6 ETH. Buy ~21966 / 3000 = ~7.322 ETH. Final: ~13.322
+    expected_eth_qty = 6.0 + (buy_trade.estimated_value_base / 3000.0)
+    assert result.projected_balances["ETH"]["quantity"] == pytest.approx(expected_eth_qty)
+
+    # Initial: 10k USDT.
+    # Sell 12k BTC -> +11988.
+    # Buy ETH -> Cost ~21988.
+    # Final: ~0 USDT (dust)
+    assert result.projected_balances["USDT"]["quantity"] == pytest.approx(0.0, abs=1.0)
 
     # Assert database write
     db_run = db_session.query(RebalanceRun).filter_by(run_id=result.run_id).first()
     assert db_run is not None
     assert db_run.status == "DRY_RUN"
     assert db_run.is_dry_run is True
-    assert len(db_run.trades_executed) == 1
+    assert len(db_run.trades_executed) == 2
     assert db_run.trades_executed[0]["asset"] == "BTC"
-    assert db_run.total_fees_usd == pytest.approx(12.0, rel=1e-3)
+    assert db_run.trades_executed[1]["asset"] == "ETH"
+    assert db_run.total_fees_usd == pytest.approx(total_fees, rel=1e-3)
     assert db_run.total_value_usd_before == pytest.approx(100000.0)
-    assert db_run.total_value_usd_after == pytest.approx(99988.0, rel=1e-3)
+    # Value after drops by total fees
+    assert db_run.total_value_usd_after == pytest.approx(100000.0 - total_fees, rel=1e-3)
     assert db_run.projected_balances["BTC"]["quantity"] == pytest.approx(1.0)
     assert db_run.trigger == "manual"
     assert db_run.base_pair == "USDT"

--- a/tests/unit/test_rebalance_engine.py
+++ b/tests/unit/test_rebalance_engine.py
@@ -74,10 +74,12 @@ def test_simple_rebalance(rebalance_engine, mock_data):
     )
     trades = result["proposed_trades"]
 
-    assert len(trades) == 1  # Sell BTC. Buy ETH skipped due to insufficient funds.
+    # With the fix, the SELL proceeds are used to fund the BUY.
+    # So we expect 2 trades: Sell BTC and Buy ETH.
+    assert len(trades) == 2
 
     sell_trade = next(t for t in trades if t.side == "SELL")
-    buy_trade = next((t for t in trades if t.side == "BUY"), None)
+    buy_trade = next(t for t in trades if t.side == "BUY")
 
     # Based on TOTAL value of 100k:
     # Sell BTC: current 75k, target 60k -> Sell 15k
@@ -87,7 +89,9 @@ def test_simple_rebalance(rebalance_engine, mock_data):
     assert sell_trade.estimated_value_usd == pytest.approx(15000, rel=1e-3)
     assert sell_trade.quantity == pytest.approx(15000 / 50000, rel=1e-3)
 
-    assert buy_trade is None
+    assert buy_trade.asset == "ETH"
+    assert buy_trade.estimated_value_base == pytest.approx(10000, rel=1e-3)
+    assert buy_trade.estimated_value_usd == pytest.approx(10000, rel=1e-3)
 
 
 def test_trade_below_min_value_is_ignored(rebalance_engine, mock_data):
@@ -132,9 +136,16 @@ def test_trade_below_min_notional_is_ignored(rebalance_engine, mock_data):
     )
     trades = result["proposed_trades"]
 
-    # No trades should be proposed. The BTC trade is below min notional,
-    # and the ETH trade is skipped due to insufficient funds.
-    assert len(trades) == 0
+    # BTC trade is below min notional (15k < 20k) -> Skipped.
+    # ETH trade (Buy ~10k) exceeds available funds (5k).
+    # New behavior: It should adjust the trade to buy as much ETH as possible with 5k.
+    assert len(trades) == 1
+    eth_trade = trades[0]
+    assert eth_trade.asset == "ETH"
+    assert eth_trade.side == "BUY"
+    # We expect it to use roughly the full 5000 USDT (minus fees)
+    # 5000 / (1 + 0.001) approx 4995
+    assert eth_trade.estimated_value_base == pytest.approx(5000 / 1.001, rel=1e-3)
 
 
 def test_asset_not_in_cmc_list_is_ignored(rebalance_engine, mock_data):
@@ -163,8 +174,8 @@ def test_asset_not_in_cmc_list_is_ignored(rebalance_engine, mock_data):
 def test_new_asset_to_buy(rebalance_engine, mock_data):
     """Test buying a new asset that is not currently in the wallet."""
     target_allocations = {"BTC": 70.0, "ETH": 20.0, "USDT": 0.0, "BNB": 10.0}
-    mock_data["balances"]["USDT"] = 15000  # Increase USDT to have funds
-    # Total value = 75k + 20k + 15k = 110k
+    mock_data["balances"]["USDT"] = 20000  # Increase USDT to have sufficient funds including fees
+    # Total value = 75k + 20k + 20k = 115k
 
     result = rebalance_engine.run(
         balances=mock_data["balances"],
@@ -182,10 +193,12 @@ def test_new_asset_to_buy(rebalance_engine, mock_data):
     buy_bnb_trade = next((t for t in trades if t.asset == "BNB"), None)
     assert buy_bnb_trade is not None
     assert buy_bnb_trade.side == "BUY"
-    # Target value is 10% of total value (110k) = 11k
-    assert buy_bnb_trade.estimated_value_base == pytest.approx(11000, rel=1e-3)
-    assert buy_bnb_trade.estimated_value_usd == pytest.approx(11000, rel=1e-3)
-    assert buy_bnb_trade.quantity == pytest.approx(11000 / 300.0, rel=1e-3)
+    # Target value is 10% of total value (115k) = 11.5k.
+    # However, due to fees consuming the cash buffer, the trade might be slightly reduced.
+    # We check that it's within 1% of the target.
+    assert buy_bnb_trade.estimated_value_base == pytest.approx(11500, rel=0.01)
+    assert buy_bnb_trade.estimated_value_usd == pytest.approx(11500, rel=0.01)
+    assert buy_bnb_trade.quantity == pytest.approx(11500 / 300.0, rel=0.01)
 
 
 def test_projected_balances_with_buy_fee(rebalance_engine, mock_data):


### PR DESCRIPTION
Refactored RebalanceEngine logic to prevent proposing trades that exceed available funds.
- Implemented running balance tracking: SELLs are processed first to credit the balance, then BUYs are processed against the running balance.
- Added partial fill logic: If funds are insufficient for a full BUY trade (e.g. due to fees) but sufficient for the minimum order size, the trade is scaled down instead of being skipped.
- Updated unit and integration tests to verify the fix and the improved liquidity handling.